### PR TITLE
Align test script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "react-app-rewired build",
     "lint": "eslint '*/**/*.{js,ts,tsx}' --max-warnings=0",
     "test": "tsc && react-app-rewired test",
-    "test:ci": "tsc && react-app-rewired test --ci ---coverage",
+    "test:ci": "tsc && react-app-rewired test --ci --coverage",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
The test isn't used, but all other web-repositories now use the name
'test:ci'. Also remove the reporters.